### PR TITLE
only play from postMessage if player el is visible

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -197,6 +197,10 @@ VideoPlayer.prototype.playerReady = function() {
   this.initPlayerEventListeners();
 };
 
+VideoPlayer.prototype.playerVisible = function() {
+  return jQuery(this.player.el()).is(':visible');
+};
+
 VideoPlayer.prototype.initPlayerEventListeners = function() {
   var that = this;
 
@@ -239,6 +243,10 @@ VideoPlayer.prototype.isPulseAdPlaying = function() {
 
 VideoPlayer.prototype.handleMessagePlay = function() {
   if (!this.player.el()) {
+    return;
+  }
+
+  if (!this.playerVisible()) {
     return;
   }
 

--- a/test/player.spec.js
+++ b/test/player.spec.js
@@ -491,26 +491,62 @@ describe('VideoPlayer', function() {
       };
     });
 
-    context('pulse ad playing', function() {
-      beforeEach(function() {
-        TestHelper.stub(videoPlayer, 'isPulseAdPlaying', true);
-        videoPlayer.handleMessagePlay();
+    context('player is not visible', function () {
+      beforeEach(function () {
+        videoPlayer.player.el().style.display = 'none';
       });
 
-      it('resumes the ad', function() {
-        expect(videoPlayer.player.vpApi.resumeAd.called).to.be.true;
+
+      context('pulse ad playing', function() {
+        beforeEach(function() {
+          TestHelper.stub(videoPlayer, 'isPulseAdPlaying', true);
+          videoPlayer.handleMessagePlay();
+        });
+
+        it('does not resume the ad', function() {
+          expect(videoPlayer.player.vpApi.resumeAd.called).to.be.false;
+        });
+      });
+
+      context('pulse ad not playing', function() {
+        beforeEach(function() {
+          TestHelper.stub(videoPlayer, 'isPulseAdPlaying', false);
+          TestHelper.stub(videoPlayer.player, 'play');
+          videoPlayer.handleMessagePlay();
+        });
+
+        it('does not resume the content', function() {
+          expect(videoPlayer.player.play.called).to.be.false;
+        });
       });
     });
 
-    context('pulse ad not playing', function() {
-      beforeEach(function() {
-        TestHelper.stub(videoPlayer, 'isPulseAdPlaying', false);
-        TestHelper.stub(videoPlayer.player, 'play');
-        videoPlayer.handleMessagePlay();
+    context('player is visible', function () {
+      beforeEach(function () {
+        videoPlayer.player.el().style.display = 'block';
       });
 
-      it('resumes the content', function() {
-        expect(videoPlayer.player.play.called).to.be.true;
+      context('pulse ad playing', function() {
+        beforeEach(function() {
+          TestHelper.stub(videoPlayer, 'isPulseAdPlaying', true);
+          videoPlayer.handleMessagePlay();
+        });
+
+        it('resumes the ad', function() {
+          expect(videoPlayer.player.vpApi.resumeAd.called).to.be.true;
+        });
+      });
+
+      context('pulse ad not playing', function() {
+        beforeEach(function() {
+          TestHelper.stub(videoPlayer, 'isPulseAdPlaying', false);
+          TestHelper.stub(videoPlayer.player, 'play');
+          videoPlayer.handleMessagePlay();
+        });
+
+        it('resumes the content', function() {
+          expect(videoPlayer.player.play.called).to.be.true;
+        });
       });
     });
   });
@@ -741,6 +777,34 @@ describe('VideoPlayer', function() {
         expect(videoPlayer.handleMessagePlayWeak.called).to.be.true;
         done();
       }, 50);
+    });
+  });
+
+  describe('#playerVisible', function () {
+    beforeEach(function () {
+      videoPlayer = new VideoPlayer(videoDiv, {
+        videoId: 3237,
+      });
+    });
+
+    context('player is visible', function () {
+      beforeEach(function () {
+        videoPlayer.player.el().style.display ='block';
+      });
+
+      it('is true', function () {
+        expect(videoPlayer.playerVisible()).to.be.true;
+      });
+    });
+
+    context('player is not visible', function () {
+      beforeEach(function () {
+        videoPlayer.player.el().style.display ='none';
+      });
+
+      it('is false', function () {
+        expect(videoPlayer.playerVisible()).to.be.false;
+      });
     });
   });
 });


### PR DESCRIPTION
Re: https://trello.com/c/Suik54Qd/68-bug-both-video-players-playing-audio

Modifies the postMessage `play` event handler.

Handler checks if the `player.el()` is visible according to jQuery.

If video is not visible, it will not resume playing it.

@spra85 @kand @daytonn 

This can be confirmed by visiting:

http://www.theonion.com/special/lawn-and-garden

Run this snippet in the console:

``` javascript
$('iframe.onionstudios-playlist')[0].src = $('iframe.onionstudios-playlist')[0].src.replace('www', 'play-if-visible.test')
```

Play through the first ad, and start playing the second ad.

Scroll down past the ad to trigger the auto-pause.

Scroll back up to trigger the auto-resume.

Only one ad should be playing.
