### PR TITLE
Fix duplicate sharetools append

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.2
+
+- Fix duplicate sharetools buttons on multiple video plays
+
 # 0.1.1
 
 Modified `window.postMessage` `play` handler to check if the player is visible.

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "videohub-player",
   "description": "Onion videohub player code.",
-  "main": "dist/videohub-player.js",
+  "main": "dist/videohub-player-global.js",
   "authors": [
     "Collin Miller (Zardulist) <collintmiller@gmail.com>"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "videohub-player",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Onion videohub player code.",
   "main": "src/player.js",
   "scripts": {

--- a/src/videojs-endcard.js
+++ b/src/videojs-endcard.js
@@ -120,6 +120,8 @@ EndCard.prototype.displayShareTools = function() {
 };
 
 EndCard.prototype.endcardFetched = function(endCardMarkup) {
+  var playerElement = this.player.el();
+
   if (this.$overlay) {
     return;
   }
@@ -145,9 +147,11 @@ EndCard.prototype.endcardFetched = function(endCardMarkup) {
 
   this.displayShareTools();
 
-  this.player.el().appendChild(this.$overlay[0]);
+  playerElement.appendChild(this.$overlay[0]);
 
-  $('.sharetool').appendTo('.ec-social').show();
+  var $shareTool = $(playerElement).find('.sharetool');
+  var $endcardShareContainer = $(playerElement).find('.ec-social');
+  $shareTool.appendTo($endcardShareContainer).show();
 
   this.player.controlBar.hide();
   window.picturefill(document.querySelectorAll('.endcard [data-type="image"]'));


### PR DESCRIPTION
Crazy bug.

Was appending duplicate sets of sharetools after each video ended. So 5 video plays would have 5+ duplicate sets of sharetools (never figured out if it was linear or exponential).

@daytonn @kand @collin @spra85 
