### PR TITLE
Sharetools tries to use host property's Facebook App ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.1
+
+- Sharetools attempts to use property's FB App ID (via *meta* tag)
+
 # 1.0.0
 
 Supported the redirect v/<video id>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "videohub-player",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Onion videohub player code.",
   "main": "src/player.js",
   "scripts": {

--- a/src/sharetools.js
+++ b/src/sharetools.js
@@ -140,7 +140,9 @@
       name: 'facebook',
       url: function (params, element) {
         var ps = {
-          app_id: '632832353489701',
+          // Attempt to use host property's FB App ID, else default to OS FB App ID.
+          // Not wonderful but this player just needs to limp along until replacement.
+          app_id: $('meta[property="fb:app_id"]').attr('content') || '632832353489701',
           display: 'popup',
           link: params.url,
           name: params.title,

--- a/src/videojs-sharetools.js
+++ b/src/videojs-sharetools.js
@@ -60,7 +60,9 @@ ShareTools.prototype.setupFacebook = function($shareToolDiv) {
     name: 'facebook',
     url: function (params, element) {
       var queryParams = {
-        app_id: '632832353489701',
+        // Attempt to use host property's FB App ID, else default to OS FB App ID.
+        // Not wonderful but this player just needs to limp along until replacement.
+        app_id: $('meta[property="fb:app_id"]').attr('content') || '632832353489701',
         display: 'popup',
         link: params.url,
         name: params.title,


### PR DESCRIPTION
Fixes new sharetools regression now that video player JS is outside IFRAME, and clobbering host sharetools with onionstudios-specific sharetools + OS FB App ID. This causes an error on FB sharing b/c the OS FB App is not allowed to share "www.theonion.com" URLs.

This is a quick fix as this player is reaching end-of-life. 

@collin @kand 
